### PR TITLE
Update README (Riot to Element Rebranding)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [Riot channel](https://riot.im/app/#/room/#dappnode:matrix.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [Element channel](https://app.element.io/#/room/#DAppNode:matrix.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,10 +46,10 @@ In order to get the repositories setup before contributions refer to the [README
 
 9. _Make noise!_
 
-   Get in our [Riot](https://riot.im/app/#/room/#dappnode:matrix.org) and point to your new PR. Let us know you've tackled your first, third or 90th issue with us. We'll review it and everybody will get a warm feeling of accomplishment.
+   Get in our [Element](https://app.element.io/#/room/#DAppNode:matrix.org) and point to your new PR. Let us know you've tackled your first, third or 90th issue with us. We'll review it and everybody will get a warm feeling of accomplishment.
 
 10. _rinse, repeat_
 
     Find another issue, get more involved, make noise in our Riot, or find issues we may have missed. You've completed your first step to becoming a contributor. **You're helping to Decentralize the FUTURE**!
 
-If you still have any further questions about contribution feel free to reach out to `@eduadiez:matrix.org`, `@yalormewn:matrix.org`, `@liondapp:matrix.org`, or just make noise in the `#DAppNode` channel on [Riot](https://riot.im/app/#/room/#DAppNode:matrix.org).
+If you still have any further questions about contribution feel free to reach out to `@eduadiez:matrix.org`, `@yalormewn:matrix.org`, `@liondapp:matrix.org`, or just make noise in the `#DAppNode` channel on [Element](https://app.element.io/#/room/#DAppNode:matrix.org).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [Riot channel](https://riot.im/app/#/room/#dappnode:matrix.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [Element channel](https://app.element.io/#/room/#DAppNode:matrix.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,11 +44,11 @@ In order to get the repositories setup before contributions refer to the [README
 
 9. *Make noise!*
 
-    Get in our [Riot](https://riot.im/app/#/room/#dappnode:matrix.org) and point to your new PR. Let us know you've tackled your first, third or 90th issue with us. We'll review it and everybody will get a warm feeling of accomplishment.
+    Get in our [Element](https://app.element.io/#/room/#DAppNode:matrix.org) and point to your new PR. Let us know you've tackled your first, third or 90th issue with us. We'll review it and everybody will get a warm feeling of accomplishment.
 
 10. *rinse, repeat*
 
     Find another issue, get more involved, make noise in our Riot, or find issues we may have missed. You've completed your first step to becoming a contributor. **You're helping to Decentralize the FUTURE**!
 
 
-If you still have any further questions about contribution feel free to reach out to `@eduadiez:matrix.org`,  `@yalormewn:matrix.org`, `@liondapp:matrix.org`, or just make noise in the `#DAppNode` channel on [Riot](https://riot.im/app/#/room/#DAppNode:matrix.org).
+If you still have any further questions about contribution feel free to reach out to `@eduadiez:matrix.org`,  `@yalormewn:matrix.org`, `@liondapp:matrix.org`, or just make noise in the `#DAppNode` channel on [Element](https://app.element.io/#/room/#DAppNode:matrix.org).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Website dappnode.io](https://img.shields.io/badge/Website-dappnode.io-brightgreen.svg)](https://dappnode.io/)
 [![Documentation Wiki](https://img.shields.io/badge/Documentation-Wiki-brightgreen.svg)](https://github.com/dappnode/DAppNode/wiki)
 [![GIVETH Campaign](https://img.shields.io/badge/GIVETH-Campaign-1e083c.svg)](https://beta.giveth.io/campaigns/5b44b198647f33526e67c262)
-[![RIOT DAppNode](https://img.shields.io/badge/RIOT-DAppNode-blue.svg)](https://riot.im/app/#/room/#DAppNode:matrix.org)
+[![ELEMENT DAppNode](https://img.shields.io/badge/ELEMENT-DAppNode-blue.svg)](https://app.element.io/#/room/#DAppNode:matrix.org)
 ![GitHub All Releases](https://img.shields.io/github/downloads/dappnode/DAppNode/total.svg)
 [![Twitter Follow](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Follow)](https://twitter.com/DAppNODE?lang=es)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Where the DAppers play
 ======
 [DAppNode](https://dappnode.io/)
 
-[Riot](https://riot.im/app/#/room/#dappnode:matrix.org)
+[Element](https://app.element.io/#/room/#DAppNode:matrix.org)
 
 [Telegram](https://t.me/dappnode)
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -58,14 +58,14 @@ In order to get the repositories setup before contributions refer to the [README
 
 9. *Make noise!*
 
-    Get in our [Riot](https://riot.im/app/#/room/#dappnode:matrix.org) and point to your new PR. Let us know you've tackled your first, third or 90th issue with us. We'll review it and everybody will get a warm feeling of accomplishment.
+    Get in our [Element](https://app.element.io/#/room/#DAppNode:matrix.org) and point to your new PR. Let us know you've tackled your first, third or 90th issue with us. We'll review it and everybody will get a warm feeling of accomplishment.
 
 10. *rinse, repeat*
 
     Find another issue, get more involved, make noise in our Riot, or find issues we may have missed. You've completed your first step to becoming a contributor. **You're helping to Decentralize the FUTURE**!
 
 
-If you still have any further questions about contribution feel free to reach out to `@eduadiez:matrix.org`,  `@yalormewn:matrix.org`, `@liondapp:matrix.org`, or just make noise in the `#DAppNode` channel on [Riot](https://riot.im/app/#/room/#DAppNode:matrix.org).
+If you still have any further questions about contribution feel free to reach out to `@eduadiez:matrix.org`,  `@yalormewn:matrix.org`, `@liondapp:matrix.org`, or just make noise in the `#DAppNode` channel on [Element](https://app.element.io/#/room/#DAppNode:matrix.org).
 
 
 How to Report Issues

--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -25,4 +25,4 @@ More Questions?
 ===============
 
 If you have more questions or your question is not answered here, please talk to us on
-`riot <https://riot.im/app/#/room/#dappnode:matrix.org>`_ or file an `issue <https://github.com/dappnode/DAppNode/issues>`_.
+`element <https://app.element.io/#/room/#DAppNode:matrix.org>`_ or file an `issue <https://github.com/dappnode/DAppNode/issues>`_.


### PR DESCRIPTION
Riot has recently been rebranded to Element. This pull request and those like it on the other repositories update the branding and room address to reflect this.