### PR TITLE
added script to create iso image

### DIFF
--- a/scripts/dappnode-iso-image.sh
+++ b/scripts/dappnode-iso-image.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+INSTALLER_URL="https://github.com/dappnode/DAppNode_Installer.git"
+INSTALLER_DIR="DAppNode_Installer"
+
+## 1. Which core packages to be updated?
+
+read -p "DAPPMANAGER will be updated? (Y/N)  " DAPPMANAGER_CONFIRM
+if [[ $DAPPMANAGER_CONFIRM == [yY] ]]
+then 
+    read -p "which git tag?  " DAPPMANAGER_TAG
+fi
+
+read -p "BIND will be updated? (Y/N)  " BIND_CONFIRM
+if [[ $BIND_CONFIRM == [yY] ]]
+then 
+    read -p "which git tag?  " BIND_TAG
+fi
+
+read -p "IPFS will be updated? (Y/N)  " IPFS_CONFIRM
+if [[ $IPFS_CONFIRM == [yY] ]]
+then 
+    read -p "which git tag?  " IPFS_TAG
+fi
+
+read -p "VPN will be updated? (Y/N)  " VPN_CONFIRM
+if [[ $VPN_CONFIRM == [yY] ]]
+then 
+    read -p "which git tag?  " VPN_TAG
+fi
+
+read -p "WIFI will be updated? (Y/N)  " WIFI_CONFIRM
+if [[ $WIFI_CONFIRM == [yY] ]]
+then 
+    read -p "which git tag?  " WIFI_TAG
+fi
+
+## 2. clone installer repo 
+
+# 1 -> core package  2 -> package tag 
+function set_new_tag () {
+    sed -i -e 's/'"$1"'_VERSION:-[0-9,.]\+/'"$1"'_VERSION:-'"$2"'/' build/scripts/.dappnode_profile ## Improve substitution: exclude } and " chars 
+}
+
+git clone "$INSTALLER_URL"
+cd "$INSTALLER_DIR" || return
+
+if [ -n "$DAPPMANAGER_TAG" ]
+then
+   set_new_tag "DAPPMANAGER" "$DAPPMANAGER_TAG"
+fi 
+
+if [ -n "$BIND_TAG" ]
+then
+   set_new_tag "BIND" "$BIND_TAG"
+fi 
+
+if [ -n "$IPFS_TAG" ]
+then
+   set_new_tag "IPFS" "$IPFS_TAG"
+fi 
+
+if [ -n "$VPN_TAG" ]
+then
+   set_new_tag "VPN" "$VPN_TAG"
+fi 
+
+if [ -n "$WIFI_TAG" ]
+then
+   set_new_tag "WIFI" "$WIFI_TAG"
+fi 
+
+echo "Successfully changed core packages tags in .dappnode_profile"
+
+## 3. Create ISO image
+
+docker-compose build --no-cache
+docker-compose up
+
+## 4. Get ISO image and isolate it
+
+cp images/DAppNode-debian-bullseye-amd64.iso ../
+cd ..
+rm -rf "$INSTALLER_URL"

--- a/scripts/dappnode-iso-image.sh
+++ b/scripts/dappnode-iso-image.sh
@@ -81,4 +81,4 @@ docker-compose up
 
 cp images/DAppNode-debian-bullseye-amd64.iso ../
 cd ..
-rm -rf "$INSTALLER_URL"
+rm -rf "$INSTALLER_DIR"


### PR DESCRIPTION
**Automate ISO creation**
Usually needed when a new realese needs to be tested. 

INPUT -> which core packages will be updated and their tags. 

OUTPUT -> ISO image based on the core packages versions (including the new ones)

**Future improvemnts**
Would be a good idea to execute this script maybe inside a remote server and install it there

RESULTS

**.dappnode_profile** edited deppending on the input
![Screenshot from 2021-01-08 17-06-14](https://user-images.githubusercontent.com/41727368/104036701-042e6c80-51d4-11eb-93aa-3c2335a3e0fa.png)

**script execution**
![Screenshot from 2021-01-08 17-07-11](https://user-images.githubusercontent.com/41727368/104036753-17413c80-51d4-11eb-8ef3-7e5a1dbff8a1.png)

**ISO image as output**
![Screenshot from 2021-01-08 17-06-38](https://user-images.githubusercontent.com/41727368/104036784-21633b00-51d4-11eb-9504-b6a56f4cc3a8.png)