### PR TITLE
clean DAppNode iso image when CLEAN=true

### DIFF
--- a/iso/scripts/generate_ISO.sh
+++ b/iso/scripts/generate_ISO.sh
@@ -5,7 +5,7 @@ dockerd &
 sleep 5
 
 if [ "$CLEAN" = true ]; then
-    rm -f /images/*.iso
+    rm -f /images/DAppNode*.iso
     rm -f /images/*.tar.xz
     rm -f /images/*.yml
     rm -f /images/*.json

--- a/iso/scripts/generate_ISO.sh
+++ b/iso/scripts/generate_ISO.sh
@@ -5,6 +5,7 @@ dockerd &
 sleep 5
 
 if [ "$CLEAN" = true ]; then
+    rm -f /images/*.iso
     rm -f /images/*.tar.xz
     rm -f /images/*.yml
     rm -f /images/*.json

--- a/iso/scripts/generate_dappnode_iso_debian.sh
+++ b/iso/scripts/generate_dappnode_iso_debian.sh
@@ -15,7 +15,10 @@ fi
 echo "Done!"
 
 echo "Verifying download..."
-[[ "$(shasum -a 256 ${ISO_PATH})" != "$SHASUM" ]] && { echo "ERROR: wrong shasum"; exit 1; }
+[[ "$(shasum -a 256 ${ISO_PATH})" != "$SHASUM" ]] && {
+    echo "ERROR: wrong shasum"
+    exit 1
+}
 
 echo "Clean old files..."
 rm -rf dappnode-isoº
@@ -44,7 +47,7 @@ cd /images/bin/docker
 cd - # /usr/src/app/dappnode-iso
 
 echo "Creating necessary directories and copying files..."
-mkdir -p /usr/src/app/dappnode-iso/dappnode 
+mkdir -p /usr/src/app/dappnode-iso/dappnode
 cp -r /usr/src/app/scripts /usr/src/app/dappnode-iso/dappnode
 cp -r /usr/src/app/dappnode/* /usr/src/app/dappnode-iso/dappnode
 cp -vr /images/bin /usr/src/app/dappnode-iso/dappnode/
@@ -54,7 +57,7 @@ mkdir -p /tmp/makeinitrd
 cd install.amd
 cp initrd.gz /tmp/makeinitrd/
 if [[ ${UNATTENDED} == "true" ]]; then
-   cp /usr/src/app/iso/preseeds/preseed_unattended.cfg /tmp/makeinitrd/preseed.cfg
+    cp /usr/src/app/iso/preseeds/preseed_unattended.cfg /tmp/makeinitrd/preseed.cfg
 else
     cp /usr/src/app/iso/preseeds/preseed.cfg /tmp/makeinitrd/preseed.cfg
 fi

--- a/iso/scripts/generate_dappnode_iso_debian.sh
+++ b/iso/scripts/generate_dappnode_iso_debian.sh
@@ -56,7 +56,7 @@ echo "Customizing preseed..."
 mkdir -p /tmp/makeinitrd
 cd install.amd
 cp initrd.gz /tmp/makeinitrd/
-if [[ ${UNATTENDED} == "true" ]]; then
+if [[ $UNATTENDED == *"true"* ]]; then
     cp /usr/src/app/iso/preseeds/preseed_unattended.cfg /tmp/makeinitrd/preseed.cfg
 else
     cp /usr/src/app/iso/preseeds/preseed.cfg /tmp/makeinitrd/preseed.cfg


### PR DESCRIPTION
Clean ISO image when var CLEAN is set to true in order to avoid cache created. This may affect creating an unattended image right after the attended