### PR TITLE
Add Wireguard to all install conditions

### DIFF
--- a/scripts/dappnode_install.sh
+++ b/scripts/dappnode_install.sh
@@ -66,7 +66,7 @@ determine_packages() {
     is_port_used
     if [ "$IS_ISO_INSTALL" == "false" ]; then
         if [ "$IS_PORT_USED" == "true" ]; then
-            PKGS=(BIND IPFS VPN DAPPMANAGER WIFI)
+            PKGS=(BIND IPFS VPN WIREGUARD DAPPMANAGER WIFI)
         else
             PKGS=(HTTPS BIND IPFS WIREGUARD DAPPMANAGER WIFI)
         fi


### PR DESCRIPTION
adding wireguard to all install configs.  will fix the update script from gutting wireguard when it's run.  I dont see any situation where wireguard shouldnt be installed, unlike HTTPS etc.

@pablomendezroyo please let me know if you see any issue with this change, I'd like to merge this asap if theres no reason not to.