### PR TITLE
Fix installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Champions are community members that are in charge of maintaining packages: keep
 
 Get your DAppNode and start contributing to decentralization by running your own nodes.
 
-[Install DAppNode on your host machine](https://docs.dappnode.io/install/) or buy your DAppNode with all the stuff configured and prepared to be used in [DAppNode shop](https://shop.dappnode.io/)
+[Install DAppNode on your host machine](https://docs.dappnode.io/get-started/installation/custom-hardware/installation/overview) or buy your DAppNode with all the stuff configured and prepared to be used in [DAppNode shop](https://shop.dappnode.io/)
 
 ### Install DAppNode with ISO
 

--- a/README.md
+++ b/README.md
@@ -230,4 +230,4 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ## Copyright
 
-Copyright © (2018-2022) [The DAppNode Association](https://dappnode.io]
+Copyright © (2018-2022) [The DAppNode Association](https://dappnode.io)


### PR DESCRIPTION
The links redirected to a 404 page. Fix https://github.com/dappnode/DAppNodeDocs/issues/206