### PR TITLE
Disabled root password and adding dappnode user to sudo

### DIFF
--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -17,13 +17,13 @@ d-i netcfg/get_domain string dappnode.eth
 d-i netcfg/get_domain seen true
 
 ### Account setup
-d-i passwd/root-login boolean false # dappnode user will not be in sudo
+d-i passwd/root-login boolean false
 d-i passwd/user-fullname string DAppNode
 d-i passwd/username string dappnode
 # Use `mkpasswd -m sha-512` to  generate the hash
 # Using "dappnode.s0" as default
 d-i passwd/user-password-crypted password $6$insecur3$rnEv9Amdjn3ctXxPYOlzj/cwvLT43GjWzkPECIHNqd8Vvza5bMG8QqMwEIBKYqnj609D.4ngi4qlmt29dLE.71
-d-i passwd/root-password-crypted password $6$insecur3$rnEv9Amdjn3ctXxPYOlzj/cwvLT43GjWzkPECIHNqd8Vvza5bMG8QqMwEIBKYqnj609D.4ngi4qlmt29dLE.71
+# d-i passwd/root-password-crypted password $6$insecur3$rnEv9Amdjn3ctXxPYOlzj/cwvLT43GjWzkPECIHNqd8Vvza5bMG8QqMwEIBKYqnj609D.4ngi4qlmt29dLE.71
 
 ### Clock and time zone setup
 d-i clock-setup/utc boolean false


### PR DESCRIPTION
Disabling password for root user should make add first user to sudoers.
Test instructions:
- Install DAppNode ISO to fresh machine
- `sudo <command>` should work, i.e. ask for user password