### PR TITLE
update debian download link to archive permalink

### DIFF
--- a/iso/scripts/generate_dappnode_iso_debian.sh
+++ b/iso/scripts/generate_dappnode_iso_debian.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-# Source = https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/current/amd64/iso-cd/
+# Outdated LinkSource = https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/current/amd64/iso-cd/
+# Permalink to Source = https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/archive/11.5.0+nonfree/amd64/iso-cd/firmware-11.5.0-amd64-netinst.iso
 ISO_NAME=firmware-11.5.0-amd64-netinst.iso
 ISO_PATH="/images/${ISO_NAME}"
-ISO_URL=https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/11.5.0+nonfree/amd64/iso-cd/
+ISO_URL=https://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/archive/11.5.0+nonfree/amd64/iso-cd/
 SHASUM="ce1dcd1fa272976ddc387554202013e69ecf1b02b38fba4f8c35c8b12b8f521e  ${ISO_PATH}"
 
 echo "Downloading debian ISO image: ${ISO_NAME}..."


### PR DESCRIPTION
workflows (and builds) fail now because this script pulls from the current version released of non free bullseye firmware ISOs.  11.5 is no longer current, 11.6 has supplanted it.  Updated the script target to the new home of the 11.5 non-free ISO in the archive.