### PR TITLE
Add Lodestar to content hash installer

### DIFF
--- a/scripts/dappnode_install.sh
+++ b/scripts/dappnode_install.sh
@@ -21,7 +21,7 @@ DAPPNODE_ACCESS_CREDENTIALS_URL="https://github.com/dappnode/DAppNode/releases/l
 WGET="wget -q --show-progress --progress=bar:force"
 SWGET="wget -q -O-"
 # Other
-CONTENT_HASH_PKGS=(geth nethermind erigon prysm teku lighthouse nimbus)
+CONTENT_HASH_PKGS=(geth nethermind erigon prysm teku lighthouse nimbus lodestar)
 ARCH=$(dpkg --print-architecture)
 WELCOME_MESSAGE="\nChoose a way to connect to your DAppNode, then go to \e[1mhttp://my.dappnode\e[0m\n\n\e[1m- Wifi\e[0m\t\tScan and connect to DAppNodeWIFI. Get wifi credentials with \e[32mdappnode_wifi\e[0m\n\n\e[1m- Local Proxy\e[0m\tConnect to the same router as your DAppNode. Then go to \e[1mhttp://dappnode.local\e[0m\n\n\e[1m- Wireguard\e[0m\tDownload Wireguard app on your device. Get your dappnode wireguard credentials with \e[32mdappnode_wireguard\e[0m\n\n\e[1m- Open VPN\e[0m\tDownload OPen VPN app on your device. Get your openVPN creds with \e[32mdappnode_openvpn\e[0m\n\n\nTo see a full list of commands available execute \e[32mdappnode_help\e[0m\n"
 


### PR DESCRIPTION
adds lodestar to content hashes in the installer

Lodestar mainnet must be published before this can be merged.