### PR TITLE
Update preseed_unattended.cfg time to UTC

### DIFF
--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -26,8 +26,8 @@ d-i passwd/user-password-crypted password $6$insecur3$rnEv9Amdjn3ctXxPYOlzj/cwvL
 # d-i passwd/root-password-crypted password $6$insecur3$rnEv9Amdjn3ctXxPYOlzj/cwvLT43GjWzkPECIHNqd8Vvza5bMG8QqMwEIBKYqnj609D.4ngi4qlmt29dLE.71
 
 ### Clock and time zone setup
-d-i clock-setup/utc boolean false
-d-i time/zone string Europe/Berlin
+d-i clock-setup/utc boolean true
+d-i time/zone string UTC
 d-i clock-setup/ntp boolean true
 
 ### Partitioning


### PR DESCRIPTION
For unattended installs, it makes sense the most that we set clock to UTC timezone.