### PR TITLE
Voss preseed bookworm v5 test

### DIFF
--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -27,7 +27,6 @@ d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
 d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false   
 d-i apt-setup/cdrom/set-failed boolean false

--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -25,11 +25,12 @@ d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i apt-setup/local0/repository string http://deb.debian.org/debian/ bookworm main contrib non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false   
 d-i apt-setup/cdrom/set-failed boolean false
-d-i apt-setup/disable-cdrom-entries boolean true
 popularity-contest popularity-contest/participate boolean false
 
 ### Preseeding other packages

--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -25,9 +25,7 @@ d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian/ bookworm main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false   
 d-i apt-setup/cdrom/set-failed boolean false

--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -25,10 +25,13 @@ d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i apt-setup/local0/repository string http://deb.debian.org/debian/ bookworm main contrib non-free
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false   
 d-i apt-setup/cdrom/set-failed boolean false
+d-i apt-setup/disable-cdrom-entries boolean true
 popularity-contest popularity-contest/participate boolean false
 
 ### Preseeding other packages

--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -26,10 +26,10 @@ d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false   
 d-i apt-setup/cdrom/set-failed boolean false
+d-i apt-setup/disable-cdrom-entries boolean true
 popularity-contest popularity-contest/participate boolean false
 
 ### Preseeding other packages

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -63,10 +63,10 @@ d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
+d-i apt-setup/disable-cdrom-entries boolean true
 popularity-contest popularity-contest/participate boolean false
 d-i pkgsel/upgrade select none
 

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -62,9 +62,7 @@ d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -63,6 +63,8 @@ d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -62,10 +62,13 @@ d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-d-i apt-setup/local0/repository string http://deb.debian.org/debian/ bookworm main contrib non-free
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
+d-i apt-setup/disable-cdrom-entries boolean true
 popularity-contest popularity-contest/participate boolean false
 d-i pkgsel/upgrade select none
 

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -64,11 +64,9 @@ d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm main contrib non-free-firmware
 d-i apt-setup/local0/repository string http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
-d-i apt-setup/local0/repository string http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
 d-i apt-setup/cdrom/set-first boolean false
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
-d-i apt-setup/disable-cdrom-entries boolean true
 popularity-contest popularity-contest/participate boolean false
 d-i pkgsel/upgrade select none
 


### PR DESCRIPTION
I'm starting to confuse myself a bit, this is the 6th tweaked version of the ISO I've tried, my first attempt worked great, only issue was the apt-setup leaving CD-ROMs as install sources.  I tried 5 other edits using some info i found in examples and reading how to use the preseed files, as this is all new to me, I havnt built custom ISOs before.  i added a line to disable CD-ROM souces in apt-setup which worked.  I need to test a couple more times because i had 3 different results reinstalling this same version onto my node, first time all install unattended went great but then when it installed dappnode it threw errors about the iwlwifi firmware and on boot, and it didn't put up wifi,  next time i installed using the same USB same ISO worked the same but in the install i got an error in the select and install software but it was just a warning that let me proceed, same errors about no iwlwifi firmware on boot and during dappnode core install, again the apt sources were fixed and let me install, but then `dappnode_wireguard ` failed error about no file or no network, i was about to give up and go back to the drawing board but then just checked for the wifi network, it was there, then tried getting wireguard credentials again, came out no problem.  So it seems to work with these changes, but it's confusingly inconsistent. Im gonna wipe the drives separately before installing again but i hope this will work, if not I have one more change already sitting on another branch to be tested as my last attempt before i definitely need help finishing up.   Also i noticed that we have a bunch of unneeded files that are installed in the select and install software section that are prompted for removal first time running apt, some libraries etc.  Gonna test this again now and hope it resolves all the issues i had run into. for seemingly no reason.


Ignore like all of the above, most issues above were due to my impatience in even letting the core packages run for 5 mins, or my personal network setup for some reason i still get some of these errors listed above but i found the wifi and wireguard setup commands not working was simply not giving the packages like 5 mins to actually run before trying them and then they work flawlesslly.  
Theres a handful of packages APT tells me to remove with apt auto remove after installing any package. this is the note with the packages listed.
```
The following packages were automatically installed and are no longer required:
  docker-buildx-plugin docker-compose-plugin libglib2.0-0 libglib2.0-data
  libltdl7 libslirp0 pigz shared-mime-info slirp4netns xdg-user-dirs
Use 'sudo apt autoremove' to remove them.
```

this looks good to me now to resolve the issues with the preseed.cfg files and shows no issues so far with basic functions, obviously can tweak what packages are installed if needed. but thats out of my wheelhouse.  
I will be doing one more install myself, hopefully the final one for this particular Node and then get to full testing with packages and everything in production.  Really excited! 
Please guys let me know if you have any comments or changes but i think its time people other than myself start testing it.