### PR TITLE
Alias for compose backwards compatibility

### DIFF
--- a/.dappnode_profile
+++ b/.dappnode_profile
@@ -37,6 +37,8 @@ alias dappnode_connect='/usr/bin/bash /usr/src/dappnode/scripts/dappnode_access_
 # Return all available commands
 alias dappnode_help='echo -e "\n\tDAppNode commands available:\n\n\tdappnode_help\t\tprints out this message\n\n\tdappnode_wifi\t\tget wifi credentials (SSID and password)\n\n\tdappnode_openvpn\tget Open VPN credentials\n\n\tdappnode_wireguard\tget Wireguard VPN credentials (dappnode_wireguard --help for more info)\n\n\tdappnode_connect\tcheck connectivity methods available in DAppNode\n\n\tdappnode_status\t\tget status of dappnode containers\n\n\tdappnode_start\t\tstart dappnode containers\n\n\tdappnode_stop\t\tstop dappnode containers\n"'
 # Compose alias for backward compatibility
-alias docker-compose='docker compose'
+if docker compose version >/dev/null 2>&1; then
+    alias docker-compose='docker compose'
+fi
 
 return

--- a/.dappnode_profile
+++ b/.dappnode_profile
@@ -36,6 +36,7 @@ alias dappnode_wireguard='docker exec -i DAppNodeCore-api.wireguard.dnp.dappnode
 alias dappnode_connect='/usr/bin/bash /usr/src/dappnode/scripts/dappnode_access_credentials.sh'
 # Return all available commands
 alias dappnode_help='echo -e "\n\tDAppNode commands available:\n\n\tdappnode_help\t\tprints out this message\n\n\tdappnode_wifi\t\tget wifi credentials (SSID and password)\n\n\tdappnode_openvpn\tget Open VPN credentials\n\n\tdappnode_wireguard\tget Wireguard VPN credentials (dappnode_wireguard --help for more info)\n\n\tdappnode_connect\tcheck connectivity methods available in DAppNode\n\n\tdappnode_status\t\tget status of dappnode containers\n\n\tdappnode_start\t\tstart dappnode containers\n\n\tdappnode_stop\t\tstop dappnode containers\n"'
+# Compose alias for backward compatibility
+alias docker-compose='docker compose'
 
 return
-


### PR DESCRIPTION
Add the `docker-compose` command as an alias. In newer docker versions, docker-compose has been deprecated.

Only add the alias if docker compose does not throw an error