### PR TITLE
Enable mirror usage in preseed configuration

### DIFF
--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -57,7 +57,7 @@ d-i grub-installer/bootdev string default
 ### Package selection
 tasksel tasksel/first multiselect standard
 d-i pkgsel/include string openssh-server vim sudo build-essential linux-headers-$(uname -r) iw iwd wpasupplicant intel-microcode iucode-tool firmware-misc-nonfree firmware-iwlwifi avahi-utils iptables
-d-i apt-setup/use_mirror boolean false
+d-i apt-setup/use_mirror boolean true
 d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian


### PR DESCRIPTION
Update the preseed configuration to enable the use of a mirror for package installation.