### PR TITLE
fix: defer --update cleanup until after preflight checks pass

### DIFF
--- a/scripts/dappnode_install.sh
+++ b/scripts/dappnode_install.sh
@@ -527,16 +527,14 @@ patch_dappmanager_compose_for_macos() {
 }
 
 bootstrap_filesystem() {
-    # Clean if update
+    # Clean if update — only the logfile and profile are removed here.
+    # Removing the profile early forces ensure_profile_loaded to re-download
+    # the latest one (so resolved package versions match the new release).
+    # Composes/manifests/archives are removed later by clean_for_update,
+    # AFTER preflight passes — see comment in main().
     if [[ "${UPDATE}" == "true" ]]; then
-        log "Cleaning for update..."
         rm -f "${LOGFILE}" || true
-        rm -f "${DAPPNODE_CORE_DIR}"/docker-compose-*.yml || true
-        rm -f "${DAPPNODE_CORE_DIR}"/dappnode_package-*.json || true
-        rm -f "${DAPPNODE_CORE_DIR}"/*.tar.xz || true
-        rm -f "${DAPPNODE_CORE_DIR}"/*.txz || true
         rm -f "${DAPPNODE_CORE_DIR}/.dappnode_profile" || true
-        rm -f "${CONTENT_HASH_FILE}" || true
     fi
 
     # Create necessary directories
@@ -549,6 +547,22 @@ bootstrap_filesystem() {
 
     # Ensure the log file path exists before first use by helpers.
     touch "${LOGFILE}" || true
+}
+
+# Destructive: remove on-disk artifacts from the previous install so fresh
+# downloads take their place. Must only run AFTER preflight checks have passed —
+# otherwise a failing preflight (e.g. port conflict) leaves the host with no
+# compose files on disk while running containers continue to hold the ports.
+clean_for_update() {
+    if [[ "${UPDATE}" != "true" ]]; then
+        return 0
+    fi
+    log "Cleaning for update..."
+    rm -f "${DAPPNODE_CORE_DIR}"/docker-compose-*.yml || true
+    rm -f "${DAPPNODE_CORE_DIR}"/dappnode_package-*.json || true
+    rm -f "${DAPPNODE_CORE_DIR}"/*.tar.xz || true
+    rm -f "${DAPPNODE_CORE_DIR}"/*.txz || true
+    rm -f "${CONTENT_HASH_FILE}" || true
 }
 
 # Generic helper: returns 0 if a process is bound to the given port, 1 if not.
@@ -1107,6 +1121,10 @@ main() {
     configure_static_ip
     ensure_profile_loaded
     resolve_packages
+    # Destructive cleanup runs only after preflight (resolve_packages -> check_vpn_ports_conflict)
+    # has passed; otherwise a failing port check would wipe the on-disk composes while the
+    # running containers still hold the ports, leaving the node un-restartable.
+    clean_for_update
 
     echo "" 2>&1 | tee -a "$LOGFILE"
     log "##############################################"

--- a/scripts/dappnode_install.sh
+++ b/scripts/dappnode_install.sh
@@ -605,6 +605,8 @@ check_https_ports_conflict() {
 
 # Check that ports required by VPN/Wireguard are not already in use by another process.
 # Must be called after PKGS is populated. Exits with a helpful error on conflict.
+# Ports held by our own dappnode core VPN/Wireguard containers are not conflicts —
+# the upcoming compose-up will replace them.
 check_vpn_ports_conflict() {
     if ! command -v lsof >/dev/null 2>&1; then
         return  # cannot check; proceed and let the container report a bind error
@@ -615,11 +617,16 @@ check_vpn_ports_conflict() {
         case "$pkg" in
             WIREGUARD)
                 if is_port_listening 51820 udp; then
-                    error "Port 51820/UDP is already in use on this host."
-                    error "This port is required by the Wireguard package and must be free before installing."
-                    error "Free up port 51820 and re-run the installer, or — if you do not need VPN"
-                    error "connectivity — consider using --minimal instead (advanced users only)."
-                    exit 1
+                    # Port 51820 is in use; check if it's our own Wireguard container
+                    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qE "^DAppNodeCore-.*wireguard.*\.dnp\.dappnode\.eth$"; then
+                        log "Port 51820/UDP is held by the existing DAppNode Wireguard container; it will be replaced."
+                    else
+                        error "Port 51820/UDP is already in use on this host."
+                        error "This port is required by the Wireguard package and must be free before installing."
+                        error "Free up port 51820 and re-run the installer, or — if you do not need VPN"
+                        error "connectivity — consider using --minimal instead (advanced users only)."
+                        exit 1
+                    fi
                 fi
                 ;;
             VPN)
@@ -627,11 +634,16 @@ check_vpn_ports_conflict() {
                 is_port_listening 1194 udp && vpn_blocked+=(1194/UDP)
                 is_port_listening 8092 tcp && vpn_blocked+=(8092/TCP)
                 if [[ ${#vpn_blocked[@]} -gt 0 ]]; then
-                    error "Port(s) ${vpn_blocked[*]} are already in use on this host."
-                    error "These ports are required by the OpenVPN package and must be free before installing."
-                    error "Free up the port(s) and re-run the installer, or — if you do not need VPN"
-                    error "connectivity — consider using --minimal instead (advanced users only)."
-                    exit 1
+                    # Port(s) in use; check if held by our own OpenVPN container
+                    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^DAppNodeCore-vpn.dnp.dappnode.eth$"; then
+                        log "Port(s) ${vpn_blocked[*]} are held by the existing DAppNode VPN container; it will be replaced."
+                    else
+                        error "Port(s) ${vpn_blocked[*]} are already in use on this host."
+                        error "These ports are required by the OpenVPN package and must be free before installing."
+                        error "Free up the port(s) and re-run the installer, or — if you do not need VPN"
+                        error "connectivity — consider using --minimal instead (advanced users only)."
+                        exit 1
+                    fi
                 fi
                 ;;
         esac


### PR DESCRIPTION
## Summary

- Fix `--update` data-loss bug: a failing preflight check (e.g. VPN port conflict) used to wipe on-disk artifacts before the script had decided whether the install would proceed.
- Destructive cleanup (`docker-compose-*.yml`, `dappnode_package-*.json`, `*.txz`, `*.tar.xz`, `packages-content-hash.csv`) is now deferred to a new `clean_for_update` function called after `resolve_packages`.
- `bootstrap_filesystem` still removes the logfile and `.dappnode_profile` early, so `ensure_profile_loaded` re-downloads the latest profile (preserving existing behavior).
- `check_vpn_ports_conflict` now recognizes ports held by our own VPN/Wireguard core containers (mirroring the existing `check_https_ports_conflict` pattern), so an `--update` on a running node no longer aborts on its own ports.

## Why

In `main()`, `bootstrap_filesystem` ran the `UPDATE=true` cleanup block before `resolve_packages` invoked `check_vpn_ports_conflict`. If the port check failed and exited the script, `/usr/src/dappnode/DNCORE/` ended up with no compose files on disk. The currently running containers stayed up (they hold the ports), so the node kept working until the next restart — at which point nothing came back, because the YAML was gone.

## Repro (before this PR)

On any existing dappnode where the OpenVPN container is bound to 1194/UDP + 8092/TCP:

```bash
sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --update
```

The script aborts on the port conflict and `/usr/src/dappnode/DNCORE/` is left empty of composes/manifests/archives.

## After this PR

`--update` on a running node now proceeds normally: the self-aware port check recognizes our own VPN/Wireguard containers as non-conflicts and lets the install replace them. Even if a real port conflict is detected (foreign process), the destructive cleanup is skipped, so the previous artifacts remain on disk and the node is unaffected.

## Test plan

- [ ] Fresh install on Linux (no `--update`): unchanged behavior.
- [x] `--update` on a node with the OpenVPN container holding 1194/UDP + 8092/TCP: script logs that the existing VPN container will be replaced and proceeds with the update.
- [x] `--update` on a node with the Wireguard container holding 51820/UDP: script logs that the existing Wireguard container will be replaced and proceeds with the update.
- [ ] `--update` with a real foreign-process conflict on 1194/UDP, 8092/TCP, or 51820/UDP: script aborts with the port conflict error AND `/usr/src/dappnode/DNCORE/` still contains the previous `docker-compose-*.yml`, `dappnode_package-*.json`, and `*.txz` files.
- [ ] macOS install path unaffected.
