### PR TITLE
Improve ISO update workflow: close stale PRs and use GitHub App token

### DIFF
--- a/.github/workflows/update-base-isos.yml
+++ b/.github/workflows/update-base-isos.yml
@@ -6,15 +6,17 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update-ubuntu-iso:
     name: Check for Ubuntu ISO updates
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.TROPI_APP_ID }}
+          private-key: ${{ secrets.TROPI_APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@v6
 
@@ -59,10 +61,21 @@ jobs:
           echo "current_iso=$CURRENT_ISO" >> "$GITHUB_OUTPUT"
           echo "latest_iso=$LATEST_ISO" >> "$GITHUB_OUTPUT"
 
+      - name: Close outdated Ubuntu ISO PR
+        if: steps.ubuntu.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          EXISTING_PR=$(gh pr list --head auto/update-ubuntu-iso --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR" --comment "Superseded by a newer Ubuntu ISO version (${{ steps.ubuntu.outputs.latest_iso }})." --delete-branch
+          fi
+
       - name: Create Pull Request for Ubuntu ISO update
         if: steps.ubuntu.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Update Ubuntu base ISO to ${{ steps.ubuntu.outputs.latest_iso }}"
           branch: auto/update-ubuntu-iso
           delete-branch: true
@@ -80,6 +93,12 @@ jobs:
     name: Check for Debian ISO updates
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.TROPI_APP_ID }}
+          private-key: ${{ secrets.TROPI_APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@v6
 
@@ -139,10 +158,21 @@ jobs:
           echo "current_iso=$CURRENT_ISO" >> "$GITHUB_OUTPUT"
           echo "latest_iso=$LATEST_ISO" >> "$GITHUB_OUTPUT"
 
+      - name: Close outdated Debian ISO PR
+        if: steps.debian.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          EXISTING_PR=$(gh pr list --head auto/update-debian-iso --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR" --comment "Superseded by a newer Debian ISO version (${{ steps.debian.outputs.latest_iso }})." --delete-branch
+          fi
+
       - name: Create Pull Request for Debian ISO update
         if: steps.debian.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Update Debian base ISO to ${{ steps.debian.outputs.latest_iso }}"
           branch: auto/update-debian-iso
           delete-branch: true


### PR DESCRIPTION
Improves the `update-base-isos` workflow with two changes:

**1. Close outdated PRs before opening new ones**
If a previous auto-PR for an ISO update is still open when a newer version is detected, the workflow now closes it with a comment explaining it was superseded, then opens a fresh PR for the latest version.

**2. Use GitHub App token (`TROPI_APP_ID` / `TROPI_APP_PRIVATE_KEY`)**
Replaces `secrets.GITHUB_TOKEN` with a token generated via `actions/create-github-app-token`. This ensures CI workflows are triggered on the auto-created PRs (the default `GITHUB_TOKEN` does not trigger downstream workflows by design).