### PR TITLE
Disable NVMe power save in ISO installs

### DIFF
--- a/iso/boot/grub.cfg
+++ b/iso/boot/grub.cfg
@@ -29,7 +29,7 @@ set theme=/boot/grub/theme/1
 # }
 menuentry --hotkey=i 'Press [Enter] to Install DAppNode' {
     set background_color=black
-    linux    /install.amd/vmlinuz vga=788 FRONTEND_BACKGROUND=dark --- quiet 
+    linux    /install.amd/vmlinuz vga=788 nvme_core.default_ps_max_latency_us=0 FRONTEND_BACKGROUND=dark --- quiet
     initrd   /install.amd/initrd.gz
 }
 # submenu --hotkey=a 'Advanced options ...' {

--- a/iso/boot/txt.cfg
+++ b/iso/boot/txt.cfg
@@ -1,4 +1,4 @@
 label install
 	menu label ^Install
 	kernel /install.amd/vmlinuz
-	append vga=788 initrd=/install.amd/initrd.gz FRONTEND_BACKGROUND=dark --- quiet 
+	append vga=788 initrd=/install.amd/initrd.gz nvme_core.default_ps_max_latency_us=0 FRONTEND_BACKGROUND=dark --- quiet

--- a/iso/boot/ubuntu/grub.cfg
+++ b/iso/boot/ubuntu/grub.cfg
@@ -16,6 +16,6 @@ set theme=/boot/grub/themes/dappnode/theme.txt
 menuentry "Install Dappnode (over Ubuntu Server)" {
   set background_color=black
   set gfxpayload=keep # Maintain the graphical resolution through the booting
-  linux   /casper/vmlinuz autoinstall vga=788 FRONTEND_BACKGROUND=dark --- # Added autoinstall to make it unattended
+  linux   /casper/vmlinuz autoinstall vga=788 nvme_core.default_ps_max_latency_us=0 FRONTEND_BACKGROUND=dark --- # Added autoinstall to make it unattended
   initrd  /casper/initrd
 }

--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -37,6 +37,9 @@ d-i preseed/late_command string \
     in-target mkdir -p /usr/src/dappnode; \
     cp -ar /cdrom/dappnode/* /target/usr/src/dappnode/; \
     cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local; \
+    mkdir -p /target/etc/default/grub.d; \
+    echo 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nvme_core.default_ps_max_latency_us=0"' > /target/etc/default/grub.d/dappnode-nvme-power-save.cfg; \
+    in-target update-grub; \
     in-target chmod +x /usr/src/dappnode/scripts/dappnode_install_pre.sh; \
     in-target chmod +x /usr/src/dappnode/scripts/static_ip.sh; \
     in-target gpasswd -a $(getent passwd "1000" | cut -d: -f1) sudo; \

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -77,6 +77,9 @@ d-i preseed/late_command string \
     cp -a /etc/network/interfaces /target/etc/network/interfaces; \
     cp -ar /cdrom/dappnode/* /target/usr/src/dappnode/; \
     cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local; \
+    mkdir -p /target/etc/default/grub.d; \
+    echo 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT nvme_core.default_ps_max_latency_us=0"' > /target/etc/default/grub.d/dappnode-nvme-power-save.cfg; \
+    in-target update-grub; \
     in-target chmod +x /usr/src/dappnode/scripts/dappnode_install_pre.sh; \
     in-target touch /usr/src/dappnode/.firstboot; \
     in-target /usr/src/dappnode/scripts/dappnode_install_pre.sh UPDATE

--- a/iso/preseeds/ubuntu/autoinstall.yaml
+++ b/iso/preseeds/ubuntu/autoinstall.yaml
@@ -26,5 +26,11 @@ autoinstall:
     - "cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local"
     - "chmod +x /target/usr/src/dappnode/scripts/dappnode_install_pre.sh"
     - "touch /target/usr/src/dappnode/.firstboot"
+    - "mkdir -p /target/etc/default/grub.d"
+    - >-
+      echo 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT
+      nvme_core.default_ps_max_latency_us=0"'
+      > /target/etc/default/grub.d/dappnode-nvme-power-save.cfg
+    - "curtin in-target --target=/target -- update-grub"
     - "cp -ar /etc/netplan/* /target/etc/netplan/"  # Necessary for prerequisites
     - "curtin in-target --target=/target -- /usr/src/dappnode/scripts/dappnode_install_pre.sh UPDATE"

--- a/iso/preseeds/ubuntu/autoinstall_unattended.yaml
+++ b/iso/preseeds/ubuntu/autoinstall_unattended.yaml
@@ -40,6 +40,12 @@ autoinstall:
     - "cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local"
     - "chmod +x /target/usr/src/dappnode/scripts/dappnode_install_pre.sh"
     - "touch /target/usr/src/dappnode/.firstboot"
+    - "mkdir -p /target/etc/default/grub.d"
+    - >-
+      echo 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT
+      nvme_core.default_ps_max_latency_us=0"'
+      > /target/etc/default/grub.d/dappnode-nvme-power-save.cfg
+    - "curtin in-target --target=/target -- update-grub"
     - "cp -ar /etc/netplan/* /target/etc/netplan/"  # Necessary for prerequisites
     - "curtin in-target --target=/target -- /usr/src/dappnode/scripts/dappnode_install_pre.sh UPDATE"
     # TODO: Handle /etc/network/interfaces and /etc/network/devhotplug


### PR DESCRIPTION
## Description

Disable NVMe APST/power-save mode for ISO installs by adding `nvme_core.default_ps_max_latency_us=0` to installer boot entries and to the installed system GRUB defaults generated by Debian preseed and Ubuntu autoinstall.

This targets intermittent crashes seen on some NVMe systems, including ASUS NUC 15 Pro hardware, where disabling NVMe power saving avoids periodic lockups.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] ISO install
- [ ] Script install
- [x] Other (please detail)

Validated locally:

- `git diff --check`
- `bash -n scripts/dappnode_install_pre.sh`
- Parsed both Ubuntu autoinstall YAML files with Ruby YAML loader

**Test Configuration**:

- DAppNode version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
